### PR TITLE
Bug fix: empty conditions

### DIFF
--- a/code/dataobjects/AdvancedReport.php
+++ b/code/dataobjects/AdvancedReport.php
@@ -484,12 +484,14 @@ class AdvancedReport extends DataObject implements PermissionProvider {
 	 * Assumes the user has provided some values for the $this->ConditionFields etc. Converts
 	 * everything to an array that is run through the dbQuote() util method that handles all the
 	 * escaping
+	 *
+	 * @return array
 	 */
 	protected function getConditions() {
 		$reportFields = $this->getReportableFields();
 		$fields = $this->ConditionFields->getValues();
 		if (!$fields || !count($fields)) {
-			return '';
+			return array();
 		}
 
 		$ops = $this->ConditionOps->getValues();

--- a/code/dataobjects/DataObjectReport.php
+++ b/code/dataobjects/DataObjectReport.php
@@ -61,6 +61,9 @@ class DataObjectReport extends AdvancedReport {
 		return $fields;
 	}
 
+	/**
+	 * @return DataList
+	 */
 	public function getDataObjects() {
 		return DataList::create($this->ReportOn)
 			->filter($this->getFilter())


### PR DESCRIPTION
make sure there will always be an array returned in getConditionFilters() - this fixes the error thrown if you dont define any conditions