### PR TITLE
using a unique prefix for all translation keys

### DIFF
--- a/code/dataobjects/AdvancedReport.php
+++ b/code/dataobjects/AdvancedReport.php
@@ -137,9 +137,9 @@ class AdvancedReport extends DataObject implements PermissionProvider {
 		$columns = $config->getComponentByType('GridFieldDataColumns');
 
 		$columns->setDisplayFields(array(
-			'Title' => _t('AdvancedReports.TITLE', 'Title'),
-			'Created' => _t('AdvancedReports.GENERATED_AT', 'Generated At'),
-			'Links' => _t('AdvancedReports.LINKS', 'Links')
+			'Title' => _t('AdvancedReport.TITLE', 'Title'),
+			'Created' => _t('AdvancedReport.GENERATED_AT', 'Generated At'),
+			'Links' => _t('AdvancedReport.LINKS', 'Links')
 		));
 
 		$columns->setFieldFormatting(array(
@@ -302,7 +302,7 @@ class AdvancedReport extends DataObject implements PermissionProvider {
 			$sortGroup,
 			new MultiValueDropdownField(
 				'NumericSort',
-				_t('AdvancedReports.SORT_NUMERICALLY', 'Sort these fields numerically'),
+				_t('AdvancedReport.SORT_NUMERICALLY', 'Sort these fields numerically'),
 				$reportable
 			),
 			DropdownField::create('PaginateBy')

--- a/code/dataobjects/CombinedReport.php
+++ b/code/dataobjects/CombinedReport.php
@@ -43,7 +43,7 @@ class CombinedReport extends AdvancedReport {
 
 		if ($this->ID) {
 			$link = Controller::curr()->Link('preview');
-			$link = '<a href="' . $link . '" target="_blank">' . _t('AdvancedReports.PREVIEW', 'Preview').'</a>';
+			$link = '<a href="' . $link . '" target="_blank">' . _t('AdvancedReport.PREVIEW', 'Preview') . '</a>';
 			$fields->addFieldToTab('Root.Main', new LiteralField('Preview', $link));
 		}
 
@@ -105,7 +105,7 @@ class CombinedReport extends AdvancedReport {
 
 		$reports = $this->ChildReports();
 		if (!$reports->count()) {
-			return _t('AdvancedReports.NO_REPORTS_SELECTED', "No reports selected");
+			return _t('AdvancedReport.NO_REPORTS_SELECTED', 'No reports selected');
 		}
 
 		$contents = array();

--- a/code/dataobjects/DataObjectReport.php
+++ b/code/dataobjects/DataObjectReport.php
@@ -54,7 +54,7 @@ class DataObjectReport extends AdvancedReport {
 		ksort($types);
 
 		$fields->insertAfter(
-			new DropdownField('ReportOn', _t('AdvancedReports.REPORT_ON', 'Report on'), $types),
+			new DropdownField('ReportOn', _t('AdvancedReport.REPORT_ON', 'Report on'), $types),
 			'Title'
 		);
 

--- a/code/dataobjects/FreeformReport.php
+++ b/code/dataobjects/FreeformReport.php
@@ -139,7 +139,7 @@ class FreeformReport extends AdvancedReport {
 			$sortGroup,
 			new MultiValueDropdownField(
 				'NumericSort',
-				_t('AdvancedReports.SORT_NUMERICALLY', 'Sort these fields numerically'),
+				_t('AdvancedReport.SORT_NUMERICALLY', 'Sort these fields numerically'),
 				$reportable
 			),
 			DropdownField::create('PaginateBy')

--- a/code/extensions/ScheduledReportExtension.php
+++ b/code/extensions/ScheduledReportExtension.php
@@ -27,24 +27,24 @@ class ScheduledReportExtension extends DataExtension {
 	public function updateCMSFields($fields) {
 		if (class_exists('AbstractQueuedJob')) {
 			$fields->addFieldsToTab('Root.Schedule', array(
-				new TextField('ScheduledTitle', _t('AdvancedReports.SCHEDULED_TITLE', 'Title for scheduled report')),
-				$dt = new Datetimefield('FirstGeneration', _t('AdvancedReports.FIRST_GENERATION', 'First generation')),
+				new TextField('ScheduledTitle', _t('AdvancedReport.SCHEDULED_TITLE', 'Title for scheduled report')),
+				$dt = new Datetimefield('FirstGeneration', _t('AdvancedReport.FIRST_GENERATION', 'First generation')),
 				new DropdownField(
 					'RegenerateEvery',
-					_t('AdvancedReports.REGENERATE_EVERY', 'Regenerate every'),
+					_t('AdvancedReport.REGENERATE_EVERY', 'Regenerate every'),
 					$this->owner->dbObject('RegenerateEvery')->enumValues()
 				),
 				new TextField(
 					'RegenerateFree',
-					_t('AdvancedReports.REGENERATE_FREE', 'Scheduled (in strtotime format from first generation)')
+					_t('AdvancedReport.REGENERATE_FREE', 'Scheduled (in strtotime format from first generation)')
 				),
-				new TextField('SendReportTo', _t('AdvancedReports.SEND_TO', 'Send to email addresses')),
+				new TextField('SendReportTo', _t('AdvancedReport.SEND_TO', 'Send to email addresses')),
 			));
 
 			if ($this->owner->ScheduledJobID) {
 				$jobTime = $this->owner->ScheduledJob()->StartAfter;
 				$fields->addFieldsToTab('Root.Schedule', array(
-					new ReadonlyField('NextRunDate', _t('AdvancedReports.NEXT_RUN_DATE', 'Next run date'), $jobTime)
+					new ReadonlyField('NextRunDate', _t('AdvancedReport.NEXT_RUN_DATE', 'Next run date'), $jobTime)
 				));
 			}
 

--- a/code/pages/ReportPage.php
+++ b/code/pages/ReportPage.php
@@ -104,13 +104,13 @@ class ReportPage_Controller extends Page_Controller {
 			new FieldList(
 				new TextField(
 					'Title',
-					_t('AdvancedReports.GENERATED_REPORT_TITLE', 'Generated report title'),
+					_t('AdvancedReport.GENERATED_REPORT_TITLE', 'Generated report title'),
 					$this->ReportTemplate()->Title
 				)
 			),
 			new FieldList(
-				new FormAction('doPreview', _t('AdvancedReports.PREVIEW', 'Preview')),
-				new FormAction('doGenerate', _t('AdvancedReports.GENERATE', 'Generate'))
+				new FormAction('doPreview', _t('AdvancedReport.PREVIEW', 'Preview')),
+				new FormAction('doGenerate', _t('AdvancedReport.GENERATE', 'Generate'))
 			),
 			new RequiredFields('Title')
 		);


### PR DESCRIPTION
using a unique prefix for all translation keys. Some were "AdvancedReports" others were "AdvancedReport". Mostly they were "AdvancedReport".